### PR TITLE
Add local setup files and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,65 @@
 # SUNDECK-APP
-Sistema de gestión de prospectos, instalaciones y postventa”
+
+Sistema de gestión de prospectos, instalaciones y postventa.
+
+## Requisitos previos
+
+- Python 3.10 o superior.
+- Node.js 18 o superior (incluye npm).
+- Una instancia de MongoDB accesible localmente (por ejemplo, mediante Docker o una instalación local).
+- Una clave de API de OpenAI para las funcionalidades asistidas por IA.
+
+## Configuración del backend (FastAPI)
+
+1. Ve al directorio del backend:
+   ```bash
+   cd backend
+   ```
+2. (Opcional) Crea y activa un entorno virtual:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # En Windows usa .venv\Scripts\activate
+   ```
+3. Instala las dependencias necesarias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Copia el archivo de variables de entorno de ejemplo y completa los valores necesarios:
+   ```bash
+   cp .env.example .env
+   ```
+5. Asegúrate de que MongoDB esté en ejecución. Puedes levantar una instancia rápida con Docker:
+   ```bash
+   docker run -d --name mongodb -p 27017:27017 mongo:7
+   ```
+6. Inicia el servidor de desarrollo de FastAPI:
+   ```bash
+   uvicorn main:app --reload --port 8000
+   ```
+
+El backend quedará disponible en `http://localhost:8000` y expone la documentación interactiva en `http://localhost:8000/docs`.
+
+## Configuración del frontend (Vite + React)
+
+1. Abre una nueva terminal y navega al directorio del frontend:
+   ```bash
+   cd frontend
+   ```
+2. Instala las dependencias de Node:
+   ```bash
+   npm install
+   ```
+3. Inicia el servidor de desarrollo de Vite:
+   ```bash
+   npm run dev
+   ```
+
+El frontend quedará disponible en `http://localhost:5173` y consumirá automáticamente la API del backend en `http://localhost:8000`.
+
+## Uso de la aplicación
+
+1. Abre el navegador en `http://localhost:5173`.
+2. Crea prospectos y gestiona su flujo a través del tablero Kanban.
+3. Consulta métricas, escalaciones, materiales de capacitación y plantillas a través de las distintas pestañas de la interfaz.
+
+Con estos pasos deberías poder ejecutar SUNDECK-APP localmente sin depender de servicios externos.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+# Copia este archivo a .env y reemplaza los valores con tus credenciales locales.
+
+# Clave de API para los servicios de OpenAI utilizados en las funcionalidades de IA.
+OPENAI_API_KEY=tu_clave_de_openai
+
+# Cadena de conexión de MongoDB utilizada por la aplicación.
+MONGODB_URI=mongodb://localhost:27017

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,13 +10,22 @@ from pydantic import BaseModel, Field
 import motor.motor_asyncio
 from bson import ObjectId
 import os
+from dotenv import load_dotenv
 from openai import AsyncOpenAI
+
+load_dotenv()
+
+MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 app = FastAPI()
 
-ai_client = AsyncOpenAI()
+if OPENAI_API_KEY:
+    ai_client = AsyncOpenAI(api_key=OPENAI_API_KEY)
+else:
+    ai_client = AsyncOpenAI()
 
-client = motor.motor_asyncio.AsyncIOMotorClient("mongodb://localhost:27017")
+client = motor.motor_asyncio.AsyncIOMotorClient(MONGODB_URI)
 db = client.sundeck
 prospectos_collection = db.prospectos
 etapas_collection = db.etapas

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.110,<0.112
+uvicorn[standard]>=0.29,<0.30
+motor>=3.3,<4.0
+pydantic>=2.6,<3.0
+python-dotenv>=1.0,<2.0
+openai>=1.12,<2.0
+python-multipart>=0.0.6,<0.0.10
+aiofiles>=23.2,<24.0


### PR DESCRIPTION
## Summary
- load environment variables in the FastAPI app and allow configuring the MongoDB URI
- add backend requirements and example environment file to simplify local setup
- expand the README with detailed backend and frontend run instructions

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68c84dab680c83209616c93fbab73f79